### PR TITLE
Fix bug tf.app

### DIFF
--- a/tensorflow_serving/example/mnist_client.py
+++ b/tensorflow_serving/example/mnist_client.py
@@ -47,7 +47,7 @@ tf.compat.v1.app.flags.DEFINE_integer('num_tests', 100, 'Number of test images')
 tf.compat.v1.app.flags.DEFINE_string('server', '',
                                      'PredictionService host:port')
 tf.compat.v1.app.flags.DEFINE_string('work_dir', '/tmp', 'Working directory. ')
-FLAGS = tf.app.flags.FLAGS
+FLAGS = tf.compat.v1.app.flags.FLAGS
 
 
 class _ResultCounter(object):


### PR DESCRIPTION
Traceback (most recent call last):
  File "tensorflow_serving/example/mnist_client.py", line 50, in <module>
    FLAGS = tf.app.flags.FLAGS
AttributeError: module 'tensorflow' has no attribute 'app'